### PR TITLE
Updating base image to alpine

### DIFF
--- a/build/docker/jenkins-operator/Dockerfile
+++ b/build/docker/jenkins-operator/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/
 RUN make -f build/Makefile install-dep linux
 
 # Copy the controller-manager into a thin image
-FROM ubuntu:latest
+FROM alpine:3.8
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/maratoid/jenkins-operator/jenkins-operator .
 ENTRYPOINT ["./jenkins-operator", "--alsologtostderr", "--install-crds=true"]


### PR DESCRIPTION
There are 2 reasons for this change:
1. Alpine is significantly smaller. That is less to move across the
   network and cache
2. Alpine has fewer pieces to have security vulnerabilities in.
   Ubuntu often has known vulnerabilities in their releases that
   have not been dealt with.

Note, with such a big change you should test this and make sure it really works in practice. I also filed https://github.com/kubernetes-sigs/controller-tools/issues/90 on the topic.