### PR TITLE
[WIP] Updated to use pinned versions and charts best practices

### DIFF
--- a/deployments/helm/jenkins-operator/templates/deployment.yaml
+++ b/deployments/helm/jenkins-operator/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["./jenkins-operator"]
           args: {{ toJson .Values.args }}

--- a/deployments/helm/jenkins-operator/templates/deployment.yaml
+++ b/deployments/helm/jenkins-operator/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["./jenkins-operator"]
           args: {{ toJson .Values.args }}

--- a/deployments/helm/jenkins-operator/values.yaml
+++ b/deployments/helm/jenkins-operator/values.yaml
@@ -5,8 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/samsung_cnct/jenkins-operator
-  tag: 0.1.0-5d158905258b5c7534b08cb5bcc7057914342f8b
+  repository: quay.io/samsung_cnct/jenkins-operator:0.1.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/deployments/helm/jenkins-operator/values.yaml
+++ b/deployments/helm/jenkins-operator/values.yaml
@@ -5,8 +5,9 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/samsung_cnct/jenkins-operator:prod
-  pullPolicy: Always
+  repository: quay.io/samsung_cnct/jenkins-operator
+  tag: 0.1.0-5d158905258b5c7534b08cb5bcc7057914342f8b
+  pullPolicy: IfNotPresent
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
In the [upstream chart review guidelines](https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md) it notes to structure the image information this way. `IfNotPresent` enables local caching in the cluster.

Since we should be removing migrations from the docs this update deals with people using it directly from Git or us up-streaming the chart and having it in a form where that can happen. Though, befoore we upstream it we need semver released tags.

Marking as WIP while we figure out our strategy to upstream this.

